### PR TITLE
Use spoofed User-Agent and Referer in headers

### DIFF
--- a/app/api/gen/route.ts
+++ b/app/api/gen/route.ts
@@ -26,6 +26,8 @@ export async function GET(request: NextRequest) {
       status: backendResponse.status,
       headers: {
         "User-Agent": "curl/7.79.1", // bypasses LocalXpose warning page
+        Accept: "*/*",
+        Referer: "http://localhost",
         "Content-Type":
           backendResponse.headers.get("Content-Type") || "text/plain",
       },

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -5,6 +5,8 @@ export async function GET() {
     const res = await fetch(`${process.env.TUNNEL}/api/models`, {
       headers: {
         "User-Agent": "curl/7.79.1", // bypasses LocalXpose warning page
+        Accept: "*/*",
+        Referer: "http://localhost",
         "Content-Type": "application/json",
       },
     });


### PR DESCRIPTION
This should bypass the LocalXpose consent/warning HTML page.