### PR TITLE
Use ngrok headers in API routes

### DIFF
--- a/app/api/gen/route.ts
+++ b/app/api/gen/route.ts
@@ -18,9 +18,7 @@ export async function GET(request: NextRequest) {
   try {
     const backendResponse = await fetch(backendUrl, {
       headers: {
-        "User-Agent": "curl/7.79.1",
-        Accept: "*/*",
-        Referer: "http://localhost",
+        "ngrok-skip-browser-warning": "true",
       },
     });
 
@@ -31,6 +29,7 @@ export async function GET(request: NextRequest) {
     return new Response(backendResponse.body, {
       status: backendResponse.status,
       headers: {
+        "ngrok-skip-browser-warning": "true",
         "Content-Type":
           backendResponse.headers.get("Content-Type") || "text/plain",
       },

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -4,9 +4,7 @@ export async function GET() {
   try {
     const res = await fetch(`${process.env.TUNNEL}/api/models`, {
       headers: {
-        "User-Agent": "curl/7.79.1", // bypasses LocalXpose warning page
-        Accept: "*/*",
-        Referer: "http://localhost",
+        "ngrok-skip-browser-warning": "true",
         "Content-Type": "application/json",
       },
     });


### PR DESCRIPTION
[backend#10](https://github.com/m3chat/backend/pull/10) replaces LocalXpose with ngrok due to LocalXpose being unstable and having a warning page, rendering the API useless.

[backend#10](https://github.com/m3chat/backend/pull/10) uses ngrok to tunnel the API with a `ngrok-skip-browser-warning` header, this PR adds that header to the `api/gen` and `api/models` routes.